### PR TITLE
build: add libpq-dev as build dependency ahead of v0.4.0 upgrade

### DIFF
--- a/docker/chronicle.dockerfile
+++ b/docker/chronicle.dockerfile
@@ -26,6 +26,11 @@ RUN if [ "${RELEASE}" = "yes" ]; then \
 
 WORKDIR /
 FROM ubuntu:focal AS domain
+
+RUN apt-get update && \
+  apt-get install -y \
+  libpq-dev
+
 COPY --from=builder --chown=root:bin /usr/local/bin/chronicle /usr/local/bin
 COPY --chown=root:bin entrypoint /entrypoint
 RUN chmod 755 \


### PR DESCRIPTION
Signed-off-by: Joseph Livesey <joseph.livesey@btp.works>