### PR TITLE
fix(evidence): replace EvidenceReference with Evidence

### DIFF
--- a/domains/evidence/domain.yaml
+++ b/domains/evidence/domain.yaml
@@ -17,7 +17,7 @@ entities:
     attributes:
       - CMSId
       - Content
-  EvidenceReference:
+  Evidence:
     attributes:
       - SearchParameter
       - Reference


### PR DESCRIPTION
Brings this into line with the Chronicle documentation.

Signed-off-by: Joseph Livesey <joseph.livesey@btp.works>