### PR TITLE
in diagrams, set font darker in classes

### DIFF
--- a/docs/diagrams/include/default.iuml
+++ b/docs/diagrams/include/default.iuml
@@ -1,1 +1,2 @@
 !theme bluegray
+skinparam classFontColor darkSlateGray


### PR DESCRIPTION
There are a few ways the legibility can be improved, here's the current suggestion.

Before:
![before](https://user-images.githubusercontent.com/2630707/208478927-cb61771c-6f61-4438-91c7-0dc7c2418a77.svg)

After:
![after](https://user-images.githubusercontent.com/2630707/208478956-24a49870-078c-4d5b-b8c9-e69ddfac92fb.svg)