### PR TITLE
build(mkdocs): set code copy feature for theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ theme:
     scheme: btp
   logo: docs/assets/logos/logo.png
   favicon: docs/assets/logos/favicon.png
+  features:
+    - content.code.copy
 copyright: Copyright &copy; 2022-23 Blockchain Technology Partners Limited
 plugins:
   - same-dir


### PR DESCRIPTION
Enables the code clock copy button in the mkdocs-material theme we use, see: https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button