### PR TITLE
fix(artworld): remove quotes around type arguments in domain.yaml

### DIFF
--- a/domains/artworld/domain.yaml
+++ b/domains/artworld/domain.yaml
@@ -1,17 +1,17 @@
 name: "artworld"
 attributes:
   Title:
-    type: "String"
+    type: String
   Location:
-    type: "String"
+    type: String
   PurchaseValue:
-    type: "String"
+    type: String
   PurchaseValueCurrency:
-    type: "String"
+    type: String
   Description:
-    type: "String"
+    type: String
   Name:
-    type: "String"
+    type: String
 agents:
   Collector:
     attributes:


### PR DESCRIPTION
Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)