### PR TITLE
add in-domain documentation for Artworld

### DIFF
--- a/domains/artworld/domain.yaml
+++ b/domains/artworld/domain.yaml
@@ -1,6 +1,16 @@
+---
 name: Artworld
 attributes:
   Title:
+    doc: |
+      # `Title`
+
+      `Title` can be the title attributed to
+
+      * `Artwork`
+      * `ArtworkDetails`
+      * `Created`
+
     type: String
   Location:
     type: String
@@ -14,30 +24,293 @@ attributes:
     type: String
 agents:
   Collector:
+    doc: |
+      # `Collector`
+
+      Collectors purchase and amass collections of art.
+
+      Collectors might well be involved in exhibiting (`Exhibited`) and selling (`Sold`) works of art.
+
+      ## Examples
+
+      ```graphql
+      mutation {
+        defineCollectorAgent(
+          externalId: "collector471"
+          attributes: { nameAttribute: "Dmitry Rybolovlev" }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
     attributes:
       - Name
   Artist:
+    doc: |
+      # `Artist`
+
+      Artists create new works of art.
+
+      Artists might well be involved in exhibiting (`Exhibited`) and selling (`Sold`) works of art.
+
+      ## Examples
+
+      ```graphql
+      mutation {
+        defineArtistAgent(
+          externalId: "artist001"
+          attributes: { nameAttribute: "Leonardo da Vinci" }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
     attributes:
       - Name
 entities:
   Artwork:
+    doc: |
+      # `Artwork`
+
+      Refers to the actual physical art piece.
+
+      ## Examples
+
+      When a new artwork is created, this event can be recorded as a `Created` activity,
+      with the artist and the title of the artwork both noted.
+
+      ```graphql
+      mutation {
+        defineCreatedActivity(
+          externalId: "salvatormundi"
+          attributes: { titleAttribute: "Salvator Mundi" }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
+      The entity can be defined in Chronicle using GraphQL like so:
+
+      ```graphql
+      mutation {
+        defineArtworkEntity(
+          externalId: "salvatormundi"
+          attributes: { titleAttribute: "Salvator Mundi" }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
     attributes:
       - Title
   ArtworkDetails:
+    doc: |
+      # `ArtworkDetails`
+
+      Provides more information about the piece, such as its title and description.
+
+      ## Examples
+
+      This entity can be defined in Chronicle using GraphQL like so:
+
+      ```graphql
+      mutation {
+        defineArtworkDetailsEntity(
+          externalId: "salvatormundidetails"
+          attributes: {
+            titleAttribute: "Salvator Mundi"
+            descriptionAttribute: "Depiction of Christ holding a crystal orb and making the sign of the blessing."
+          }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
     attributes:
       - Title
       - Description
 activities:
   Exhibited:
+    doc: |
+      # `Exhibited`
+
+      `Exhibited` refers to the display of an artwork in a public space.
+
+      ## Examples
+
+      ```graphql
+      mutation {
+        defineExhibitedActivity(
+          externalId: "salvatormundiprado"
+          attributes: {
+            locationAttribute: "Prado Museum"
+          }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
     attributes:
       - Location
   Created:
+    doc: |
+      # `Created`
+
+      `Created` refers to the act of creating a new piece of art.
+
+      ## Examples
+
+      When a new artwork is created, this event can be recorded as a `Created` activity,
+      with the artist and the title of the artwork both noted.
+
+      ```graphql
+      mutation {
+        defineCreatedActivity(
+          externalId: "salvatormundi"
+          attributes: { titleAttribute: "Salvator Mundi" }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
+      Recording Associations of Artworld Agents with Artworld Activities and the Output
+
+      ```graphql
+      mutation {
+        wasAssociatedWith(
+          responsible: { externalId: "artist001" }
+          activity: { externalId: "salvatormundi" }
+          role: CREATOR
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
     attributes:
       - Title
   Sold:
+    doc: |
+      # `Sold`
+
+      `Sold` refers to the transaction between a collector and an artist,
+      in which the collector purchases the artwork for a certain amount of money.
+
+      ## Examples
+
+      When an artwork is sold, this can be recorded as a `Sold` activity,
+      along with details of the buyer and the purchase price.
+
+      ```graphql
+      mutation {
+        defineSoldActivity(
+          externalId: "saleofsalvatormundi"
+          attributes: {
+            purchaseValueAttribute: "450000000"
+            purchaseValueCurrencyAttribute: "USD"
+          }
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
+      Recording Associations of Artworld Agents with Artworld Activities and the Output
+
+      ```graphql
+      mutation {
+        wasAssociatedWith(
+          responsible: { externalId: "collector471" }
+          activity: { externalId: "saleofsalvatormundi" }
+          role: SELLER
+        ) {
+          context
+          txId
+        }
+      }
+      ```
+
+      One could query the record to determine the sale prices of artworks
+      created by a particular artist, or to see which artists are exhibiting
+      their works in a particular location.
+
+      ```graphql
+      query {
+        activityById(id: {externalId: "saleofsalvatormundi"}) {
+          ...on SoldActivity {
+            wasAssociatedWith {
+              responsible {
+                role
+                agent {
+                  ...on CollectorAgent {
+                    nameAttribute
+                    externalId
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      ```graphql
+      query {
+        activitiesByType(activityType: SoldActivity) {
+          nodes {
+            ... on SoldActivity {
+              purchaseValueAttribute
+              purchaseValueCurrencyAttribute
+              wasAssociatedWith {
+                responsible {
+                  role
+                  agent {
+                    ... on CollectorAgent {
+                      externalId
+                      nameAttribute
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      ```
+
+        attributes:
+        - PurchaseValue
+        - PurchaseValueCurrency
     attributes:
       - PurchaseValue
       - PurchaseValueCurrency
+roles_doc: |
+  # Buyer, Seller, and Creator Roles
+
+  ## Examples
+
+  In the context of association with selling (`Sold`) of an `Artwork`,
+  an `Artist`'s function could be `SELLER`, and `CREATOR` in the context
+  of creation (`Created`).
+
+  A `Collector`'s function in the context of the sale (`Sold`) of an
+  `Artwork` could be `BUYER` or `SELLER`.
 roles:
   - BUYER
   - SELLER

--- a/domains/artworld/guide.md
+++ b/domains/artworld/guide.md
@@ -322,8 +322,8 @@ ultimately enhancing trust in the art market.
 
 With a comprehensive record of the artworld in place, it is now possible to query
 this record and gain insights into the industry. For example, one could query the
-record to determine the average sale price of artworks created by a particular
-artist, or to see which artists are exhibiting their works in a particular location.
+record to determine the sale prices of artworks created by a particular artist,
+or to see which artists are exhibiting their works in a particular location.
 
 ### Querying the Associations of the Sale of an Artwork and the Output
 


### PR DESCRIPTION
Chronicle v0.7 supports generating domain-specific documentation from in-domain doc comments!

---
[CHRON-405](https://blockchaintp.atlassian.net/browse/CHRON-405)
Relates to: [CHRON-145](https://blockchaintp.atlassian.net/browse/CHRON-145)

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-145]: https://blockchaintp.atlassian.net/browse/CHRON-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CHRON-405]: https://blockchaintp.atlassian.net/browse/CHRON-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ