### PR TITLE
docs(github): add PR template with checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+# PR Checklist
+
+## Please complete this checklist after opening your PR
+
+* [ ] I have updated documentation as necessary
+* [ ] I have updated helm chart(s) if needed
+* [ ] I have added tests if needed
+* [ ] All new and existing tests are passing
+* [ ] Any breaking changes are clearly flagged and documented
+* [ ] I’ve included a link to any relevant ticket(s)


### PR DESCRIPTION
Adds a GitHub PR template with a basic checklist for new PRs

DOPS-53