### PR TITLE
pass environment variables for stop-stl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ stop-stl-$(1): $(1)-stl-debug
 	export CHRONICLE_TP_IMAGE=$(CHRONICLE_TP_IMAGE); \
 	export CHRONICLE_VERSION=$(ISOLATION_ID); \
 	export CHRONICLE_TP_VERSION=$(CHRONICLE_VERSION); \
+	export CHRONICLE_ENV_FILE=$(DOCKER_COMPOSE_ENV); \
 	$(DOCKER_COMPOSE) -f docker/chronicle.yaml down
 
 


### PR DESCRIPTION
Missing piece of #95, to prevent `make stop-stl-*` reporting,
> WARNING: The CHRONICLE_ENV_FILE variable is not set. Defaulting to a blank string.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
